### PR TITLE
avoid legacy ec2 dependencies

### DIFF
--- a/apis/route53/v1alpha1/referencers.go
+++ b/apis/route53/v1alpha1/referencers.go
@@ -23,8 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
-
-	"github.com/crossplane/provider-aws/apis/ec2/v1beta1"
 )
 
 // ResolveReferences of this Zone
@@ -44,31 +42,6 @@ func (mg *ResourceRecordSet) ResolveReferences(ctx context.Context, c client.Rea
 	}
 	mg.Spec.ForProvider.ZoneID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.ZoneIDRef = rsp.ResolvedReference
-
-	return nil
-}
-
-// ResolveReferences of a VPC provided for a HostedZone
-func (mg *HostedZone) ResolveReferences(ctx context.Context, c client.Reader) error {
-	if mg.Spec.ForProvider.VPC == nil {
-		return nil
-	}
-	r := reference.NewAPIResolver(c, mg)
-
-	// Resolve spec.forProvider.vpc.vpcId
-	rsp, err := r.Resolve(ctx, reference.ResolutionRequest{
-		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.VPC.VPCID),
-		Reference:    mg.Spec.ForProvider.VPC.VPCIDRef,
-		Selector:     mg.Spec.ForProvider.VPC.VPCIDSelector,
-		To:           reference.To{Managed: &v1beta1.VPC{}, List: &v1beta1.VPCList{}},
-		Extract:      reference.ExternalName(),
-	})
-	if err != nil {
-		return errors.Wrap(err, "spec.forProvider.vpc.vpcId")
-	}
-
-	mg.Spec.ForProvider.VPC.VPCID = reference.ToPtrValue(rsp.ResolvedValue)
-	mg.Spec.ForProvider.VPC.VPCIDRef = rsp.ResolvedReference
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

crossplane use legacy `aws-sdk-go-v2` dep which is not compatible with infra-api, this PR remove ec2 deps in route53 package
