### PR TITLE
fix aws peering post-processing

### DIFF
--- a/pkg/controller/rds/globalcluster/zz_conversions.go
+++ b/pkg/controller/rds/globalcluster/zz_conversions.go
@@ -33,7 +33,6 @@ import (
 func GenerateDescribeGlobalClustersInput(cr *svcapitypes.GlobalCluster) *svcsdk.DescribeGlobalClustersInput {
 	res := &svcsdk.DescribeGlobalClustersInput{}
 
-
 	return res
 }
 
@@ -123,7 +122,7 @@ func GenerateGlobalCluster(resp *svcsdk.DescribeGlobalClustersOutput) *svcapityp
 		return cr
 	}
 
-return cr
+	return cr
 }
 
 // GenerateCreateGlobalClusterInput returns a create input.
@@ -151,6 +150,7 @@ func GenerateCreateGlobalClusterInput(cr *svcapitypes.GlobalCluster) *svcsdk.Cre
 
 	return res
 }
+
 // GenerateModifyGlobalClusterInput returns an update input.
 func GenerateModifyGlobalClusterInput(cr *svcapitypes.GlobalCluster) *svcsdk.ModifyGlobalClusterInput {
 	res := &svcsdk.ModifyGlobalClusterInput{}
@@ -169,12 +169,11 @@ func GenerateModifyGlobalClusterInput(cr *svcapitypes.GlobalCluster) *svcsdk.Mod
 func GenerateDeleteGlobalClusterInput(cr *svcapitypes.GlobalCluster) *svcsdk.DeleteGlobalClusterInput {
 	res := &svcsdk.DeleteGlobalClusterInput{}
 
-
 	return res
 }
 
 // IsNotFound returns whether the given error is of type NotFound or not.
 func IsNotFound(err error) bool {
 	awsErr, ok := err.(awserr.Error)
-	return ok && awsErr.Code() == "GlobalClusterNotFoundFault" 
+	return ok && awsErr.Code() == "GlobalClusterNotFoundFault"
 }

--- a/pkg/controller/vpcpeering/peering_test.go
+++ b/pkg/controller/vpcpeering/peering_test.go
@@ -73,7 +73,7 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
-		"UpToDate": {
+		"Created": {
 			args: args{
 				kube: &test.MockClient{
 					MockUpdate: test.NewMockClient().Update,
@@ -115,8 +115,8 @@ func TestObserve(t *testing.T) {
 			want: want{
 				result: managed.ExternalObservation{
 					ResourceExists:          true,
-					ResourceUpToDate:        true,
-					ResourceLateInitialized: true,
+					ResourceUpToDate:        false,
+					ResourceLateInitialized: false,
 				},
 			},
 		},
@@ -158,7 +158,7 @@ func TestObserve(t *testing.T) {
 				result: managed.ExternalObservation{
 					ResourceExists:          true,
 					ResourceUpToDate:        false,
-					ResourceLateInitialized: true,
+					ResourceLateInitialized: false,
 				},
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

Make sure the post processing operations will be executed at least once, including modify peering attributes, modify route tables and create hosted zone authorizations

formerly, there are 3 problems:
1. the ID parameter is misused, as https://github.com/tidbcloud/provider-aws/pull/12 indicates
2. modify route tables and create hosted zone authorizations does not have a retry mechanism, the peering will still be ready and synced if the operations are not completed
3. modify peering attributes will be executed in every reconciliation, cause rate limit reached