### PR TITLE
fix peering check

### DIFF
--- a/pkg/clients/peering/peering.go
+++ b/pkg/clients/peering/peering.go
@@ -24,6 +24,15 @@ func GenerateDescribeVpcPeeringConnectionsInput(cr *svcapitypes.VPCPeeringConnec
 				Name:   aws.String("tag:Name"),
 				Values: []string{cr.ObjectMeta.Name},
 			},
+			{
+				Name:   aws.String("status-code"),
+				Values: []string{
+					string(ec2.VpcPeeringConnectionStateReasonCodeInitiatingRequest),
+					string(ec2.VpcPeeringConnectionStateReasonCodeActive),
+					string(ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance),
+					string(ec2.VpcPeeringConnectionStateReasonCodeProvisioning),
+				},
+			},
 		},
 	}
 

--- a/pkg/clients/peering/peering.go
+++ b/pkg/clients/peering/peering.go
@@ -25,7 +25,7 @@ func GenerateDescribeVpcPeeringConnectionsInput(cr *svcapitypes.VPCPeeringConnec
 				Values: []string{cr.ObjectMeta.Name},
 			},
 			{
-				Name:   aws.String("status-code"),
+				Name: aws.String("status-code"),
 				Values: []string{
 					string(ec2.VpcPeeringConnectionStateReasonCodeInitiatingRequest),
 					string(ec2.VpcPeeringConnectionStateReasonCodeActive),


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

Since the peering name will be reused, we should filer out deleted and failed peering to avoid the deleted peering affect current peering
