### PR TITLE
Check VPC Route Tables Existence After Deleting VPC Peering Connections

### DIFF
--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -2,7 +2,6 @@ package vpcpeering
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -523,7 +522,6 @@ func (e *external) Delete(ctx context.Context, mg cpresource.Managed) error { //
 		Filters:    []ec2.Filter{filter},
 		MaxResults: aws.Int64(10),
 	}
-	fmt.Println(describeRouteTablesInput)
 	routeTablesRes, err := e.client.DescribeRouteTablesRequest(describeRouteTablesInput).Send(ctx)
 	if err != nil {
 		return err

--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -2,6 +2,7 @@ package vpcpeering
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -522,6 +523,7 @@ func (e *external) Delete(ctx context.Context, mg cpresource.Managed) error { //
 		Filters:    []ec2.Filter{filter},
 		MaxResults: aws.Int64(10),
 	}
+	fmt.Println(describeRouteTablesInput)
 	routeTablesRes, err := e.client.DescribeRouteTablesRequest(describeRouteTablesInput).Send(ctx)
 	if err != nil {
 		return err

--- a/pkg/controller/vpcpeering/peering_test.go
+++ b/pkg/controller/vpcpeering/peering_test.go
@@ -63,6 +63,13 @@ func TestObserve(t *testing.T) {
 							}},
 						}
 					},
+					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
+						return ec2.DescribeRouteTablesRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
+								RouteTables: []ec2.RouteTable{},
+							}},
+						}
+					},
 				},
 			},
 			want: want{
@@ -110,6 +117,13 @@ func TestObserve(t *testing.T) {
 							}},
 						}
 					},
+					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
+						return ec2.DescribeRouteTablesRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
+								RouteTables: []ec2.RouteTable{},
+							}},
+						}
+					},
 				},
 			},
 			want: want{
@@ -149,6 +163,13 @@ func TestObserve(t *testing.T) {
 										VpcPeeringConnectionId: aws.String("pcx-xxx"),
 									},
 								},
+							}},
+						}
+					},
+					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
+						return ec2.DescribeRouteTablesRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
+								RouteTables: []ec2.RouteTable{},
 							}},
 						}
 					},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes
I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
