### PR TITLE
fix adopting s3 bucket

### DIFF
--- a/pkg/controller/s3/bucket/requestPaymentConfig.go
+++ b/pkg/controller/s3/bucket/requestPaymentConfig.go
@@ -98,7 +98,7 @@ func (in *RequestPaymentConfigurationClient) LateInitialize(ctx context.Context,
 
 // SubresourceExists checks if the subresource this controller manages currently exists
 func (in *RequestPaymentConfigurationClient) SubresourceExists(bucket *v1beta1.Bucket) bool {
-	return bucket.Spec.ForProvider.PayerConfiguration != nil
+	return true
 }
 
 // GeneratePutBucketPaymentInput creates the input for the BucketRequestPayment request for the S3 Client

--- a/pkg/controller/s3/bucket/requestPaymentConfig.go
+++ b/pkg/controller/s3/bucket/requestPaymentConfig.go
@@ -98,6 +98,7 @@ func (in *RequestPaymentConfigurationClient) LateInitialize(ctx context.Context,
 
 // SubresourceExists checks if the subresource this controller manages currently exists
 func (in *RequestPaymentConfigurationClient) SubresourceExists(bucket *v1beta1.Bucket) bool {
+	// RequestPaymentConfiguration resource is always exist and should be synced to CR
 	return true
 }
 


### PR DESCRIPTION
fix: https://jira.tidbcloud.com/browse/DM-2862

also helps: https://jira.tidbcloud.com/browse/DM-2832

The cause is that when the bucket is adopted, the `Create()` phase will be skipped, thus the `LateInitialize` `RequestPaymentConfiguration` is also skipped.

This PR fixes this by setting we should always `LateInitialize` the `RequestPaymentConfiguration` since a s3 bucket must have a `RequestPaymentConfiguration` which cannot be removed.

TEST:
(all bucket ready after this patch)
```
kg buckets.s3.aws.crossplane.io
NAME                                               READY   SYNCED   AGE
dbaas-staging-ap-northeast-1-1                     True    True     167m
dbaas-staging-ap-northeast-1-1369847559690857266   True    True     27d
dbaas-staging-ap-northeast-1-1369847559691067268   True    True     36d
dbaas-staging-ap-northeast-1-1369847559691097270   True    True     27d
dbaas-staging-ap-northeast-1-1369847559691367298   True    True     29d
dbaas-staging-ap-northeast-1-1369847559691367361   True    True     8m47s
dbaas-staging-ap-northeast-1-1369847559691367377   True    True     2m24s
dbaas-staging-ap-northeast-1-1369847559691367393   True    True     36d
dbaas-staging-ap-northeast-1-1369847559691367439   True    True     2d10h
dbaas-staging-ap-southeast-1-1369847559691367392   True    True     15d
dbaas-staging-ap-southeast-1-1369847559691367393   True    True     33d
dbaas-staging-us-east-1-1369847559691367298        True    True     34d
dbaas-staging-us-east-1-1369847559691367414        True    True     27d
dbaas-staging-us-west-2-1                          True    True     36d
dbaas-staging-us-west-2-1369847559690647294        True    True     36d
dbaas-staging-us-west-2-1369847559690857266        True    True     36d
dbaas-staging-us-west-2-1369847559691067266        True    True     36d
dbaas-staging-us-west-2-1369847559691127265        True    True     36d
dbaas-staging-us-west-2-1369847559691367286        True    True     36d
dbaas-staging-us-west-2-1369847559691367287        True    True     36d
dbaas-staging-us-west-2-1369847559691367298        True    True     30d
dbaas-staging-us-west-2-1369847559691367299        True    True     14d
dbaas-staging-us-west-2-1369847559691367303        True    True     36d
dbaas-staging-us-west-2-1369847559691367304        True    True     35d
dbaas-staging-us-west-2-1369847559691367322        True    True     36d
dbaas-staging-us-west-2-1369847559691367359        True    True     36d
dbaas-staging-us-west-2-1369847559691367360        True    True     36d
dbaas-staging-us-west-2-1369847559691367361        True    True     35d
dbaas-staging-us-west-2-1369847559691367384        True    True     14d
dbaas-staging-us-west-2-1369847559691367390        True    True     36d
dbaas-staging-us-west-2-1369847559691367402        True    True     36d
dbaas-staging-us-west-2-1369847559691367403        True    True     35d
dbaas-staging-us-west-2-1369847559691367404        True    True     35d
dbaas-staging-us-west-2-1369847559691367405        True    True     35d
dbaas-staging-us-west-2-1369847559691367406        True    True     35d
dbaas-staging-us-west-2-1369847559691367407        True    True     35d
dbaas-staging-us-west-2-1369847559691367408        True    True     35d
dbaas-staging-us-west-2-1369847559691367409        True    True     35d
dbaas-staging-us-west-2-1369847559691367410        True    True     35d
dbaas-staging-us-west-2-1369847559691367411        True    True     34d
dbaas-staging-us-west-2-1369847559691367415        True    True     20d
dbaas-staging-us-west-2-1369847559691367435        True    True     9d
dbaas-staging-us-west-2-1369847559691367443        True    True     4d3h
dbaas-staging-us-west-2-1369847559691367452        True    True     14h
dbaas-staging-us-west-2-aylei-test                 True    True     36d
```
