### PR TITLE
DM-2654 Clean RouteTables 

### DIFF
--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -151,7 +151,7 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{ResourceExists: false}, awsclient.Wrap(err, errDescribe)
 	}
 
-	routes, err := e.checkRoutes(ctx, cr)
+	routes, err := e.countRoutes(ctx, cr)
 	if err != nil {
 		return managed.ExternalObservation{ResourceExists: false}, err
 	}
@@ -570,7 +570,7 @@ func (e *external) deleteVPCPeeringConnection(ctx context.Context, cr *svcapityp
 	return nil
 }
 
-func (e *external) checkRoutes(ctx context.Context, cr *svcapitypes.VPCPeeringConnection) (int, error) {
+func (e *external) countRoutes(ctx context.Context, cr *svcapitypes.VPCPeeringConnection) (int, error) {
 	filter := ec2.Filter{
 		Name: aws.String("vpc-id"),
 		Values: []string{

--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -591,7 +591,7 @@ func (e *external) checkRoutes(ctx context.Context, cr *svcapitypes.VPCPeeringCo
 	var routes int
 	for _, rt := range routeTablesRes.RouteTables {
 		for _, r := range rt.Routes {
-			if r.DestinationCidrBlock == cr.Spec.ForProvider.PeerCIDR || r.DestinationIpv6CidrBlock == cr.Spec.ForProvider.PeerCIDR {
+			if r.VpcPeeringConnectionId == cr.Status.AtProvider.VPCPeeringConnectionID {
 				routes++
 			}
 		}

--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -156,8 +156,11 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{ResourceExists: false}, err
 	}
 
-	if len(resp.VpcPeeringConnections) == 0 && routes == 0 {
-		return managed.ExternalObservation{ResourceExists: false}, nil
+	if len(resp.VpcPeeringConnections) == 0 {
+		if routes == 0 {
+			return managed.ExternalObservation{ResourceExists: false}, nil
+		}
+		return managed.ExternalObservation{ResourceExists: true}, nil
 	}
 
 	existedPeer := resp.VpcPeeringConnections[0]

--- a/pkg/controller/vpcpeering/peering_test.go
+++ b/pkg/controller/vpcpeering/peering_test.go
@@ -64,6 +64,13 @@ func TestObserve(t *testing.T) {
 							}},
 						}
 					},
+					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
+						return ec2.DescribeRouteTablesRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
+								RouteTables: make([]ec2.RouteTable, 0),
+							}},
+						}
+					},
 				},
 			},
 			want: want{
@@ -111,6 +118,13 @@ func TestObserve(t *testing.T) {
 							}},
 						}
 					},
+					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
+						return ec2.DescribeRouteTablesRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
+								RouteTables: make([]ec2.RouteTable, 0),
+							}},
+						}
+					},
 				},
 			},
 			want: want{
@@ -150,6 +164,13 @@ func TestObserve(t *testing.T) {
 										VpcPeeringConnectionId: aws.String("pcx-xxx"),
 									},
 								},
+							}},
+						}
+					},
+					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
+						return ec2.DescribeRouteTablesRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
+								RouteTables: make([]ec2.RouteTable, 0),
 							}},
 						}
 					},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

- This PR is to fix: https://jira.tidbcloud.com/browse/DM-2654
- Stop requeuing the Delete() only if both the length of the routes and the length of the peeringconnections are zero, which is checked in the Observer()
- Unit tests passed
I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
