### PR TITLE
Reconcile EKS clusters and node groups.

### DIFF
--- a/apis/aws.go
+++ b/apis/aws.go
@@ -22,6 +22,8 @@ import (
 
 	ec2v1alpha1 "github.com/crossplane/provider-aws/apis/ec2/v1alpha1"
 	ec2v1beta1 "github.com/crossplane/provider-aws/apis/ec2/v1beta1"
+	eksv1alpha1 "github.com/crossplane/provider-aws/apis/eks/v1alpha1"
+	eksv1beta1 "github.com/crossplane/provider-aws/apis/eks/v1beta1"
 	elasticloadbalancingv1alpha1 "github.com/crossplane/provider-aws/apis/elasticloadbalancing/v1alpha1"
 	identityv1alpha1 "github.com/crossplane/provider-aws/apis/identity/v1alpha1"
 	identityv1beta1 "github.com/crossplane/provider-aws/apis/identity/v1beta1"
@@ -51,6 +53,8 @@ func init() {
 		kmsv1alpha1.SchemeBuilder.AddToScheme,
 		ec2v1alpha1.SchemeBuilder.AddToScheme,
 		peeringv1alpha1.SchemeBuilder.AddToScheme,
+		eksv1beta1.SchemeBuilder.AddToScheme,
+		eksv1alpha1.SchemeBuilder.AddToScheme,
 	)
 }
 

--- a/pkg/clients/aws.go
+++ b/pkg/clients/aws.go
@@ -100,6 +100,39 @@ func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed
 	switch s := pc.Spec.Credentials.Source; s { //nolint:exhaustive
 	case xpv1.CredentialsSourceInjectedIdentity:
 		cfg, err := UsePodServiceAccount(ctx, []byte{}, DefaultSection, region)
+		if err != nil {
+			return nil, err
+		}
+		if role, ok := pc.Annotations["assume-role"]; ok {
+			externalId, ok := pc.Annotations["external-id"]
+			if !ok {
+				return nil, errors.New("external-id must be set when assume-role is set")
+			}
+			stsSvc := sts.New(*cfg)
+			sess := strconv.FormatInt(time.Now().UnixNano(), 10)
+			resp, err := stsSvc.AssumeRoleRequest(&sts.AssumeRoleInput{
+				ExternalId:      &externalId,
+				RoleArn:         &role,
+				RoleSessionName: &sess,
+			}).Send(ctx)
+			if err != nil {
+				return nil, err
+			}
+			creds := aws.Credentials{
+				AccessKeyID:     aws.StringValue(resp.Credentials.AccessKeyId),
+				SecretAccessKey: aws.StringValue(resp.Credentials.SecretAccessKey),
+				SessionToken:    aws.StringValue(resp.Credentials.SessionToken),
+			}
+			configs := external.Configs([]external.Config{external.SharedConfig{
+				Credentials: creds,
+				Region:      region,
+			}})
+			config, err := configs.ResolveAWSConfig(external.DefaultAWSConfigResolvers)
+			if err != nil {
+				return nil, err
+			}
+			return SetResolver(ctx, mg, &config), err
+		}
 		return SetResolver(ctx, mg, cfg), err
 	default:
 		data, err := resource.CommonCredentialExtractor(ctx, s, c, pc.Spec.Credentials.CommonCredentialSelectors)
@@ -283,6 +316,33 @@ func GetConfigV1(ctx context.Context, c client.Client, mg resource.Managed, regi
 	}
 	switch s := pc.Spec.Credentials.Source; s { //nolint:exhaustive
 	case xpv1.CredentialsSourceInjectedIdentity:
+		if role, ok := pc.Annotations["assume-role"]; ok {
+			externalId, ok := pc.Annotations["external-id"]
+			if !ok {
+				return nil, errors.New("external-id must be set when assume-role is set")
+			}
+			cfg, err := UsePodServiceAccount(ctx, []byte{}, DefaultSection, region)
+			if err != nil {
+				return nil, errors.Wrap(err, "cannot use pod service account")
+			}
+			stsSvc := sts.New(*cfg)
+			sess := strconv.FormatInt(time.Now().UnixNano(), 10)
+			resp, err := stsSvc.AssumeRoleRequest(&sts.AssumeRoleInput{
+				ExternalId:      &externalId,
+				RoleArn:         &role,
+				RoleSessionName: &sess,
+			}).Send(ctx)
+			if err != nil {
+				return nil, err
+			}
+			creds := credentials.NewStaticCredentials(
+				aws.StringValue(resp.Credentials.AccessKeyId),
+				aws.StringValue(resp.Credentials.SecretAccessKey),
+				aws.StringValue(resp.Credentials.SessionToken))
+
+			config := SetResolverV1(ctx, mg, awsv1.NewConfig().WithCredentials(creds).WithRegion(region))
+			return session.NewSession(config)
+		}
 		cfg, err := UsePodServiceAccountV1(ctx, []byte{}, mg, DefaultSection, region)
 		if err != nil {
 			return nil, errors.Wrap(err, "cannot use pod service account")

--- a/pkg/controller/aws.go
+++ b/pkg/controller/aws.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/crossplane/provider-aws/pkg/controller/config"
 	"github.com/crossplane/provider-aws/pkg/controller/ec2/vpc"
+	"github.com/crossplane/provider-aws/pkg/controller/eks"
+	"github.com/crossplane/provider-aws/pkg/controller/eks/nodegroup"
 	"github.com/crossplane/provider-aws/pkg/controller/elasticloadbalancing/elb"
 	"github.com/crossplane/provider-aws/pkg/controller/elasticloadbalancing/elbattachment"
 	"github.com/crossplane/provider-aws/pkg/controller/identity/iampolicy"
@@ -57,6 +59,8 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter) error {
 		queue.SetupQueue,
 		key.SetupKey,
 		vpcpeering.SetupVPCPeeringConnection,
+		eks.SetupCluster,
+		nodegroup.SetupNodeGroup,
 	} {
 		if err := setup(mgr, l, rl); err != nil {
 			return err


### PR DESCRIPTION
The commit is slightly modified from commit d912a8b5756034904a2c7384d2949ac26180957a.
Changes:
- AWS controller now reconciles EKS clusters and node groups.
- AWS controller now recognizes assume-role and external-id from provider configs.
