### PR TITLE
fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
     tags:
       - "*"
   # Uncomment below lines to debug this action in PR
-  pull_request:
-    branches:
-      - pingcap/provider-aws
+#  pull_request:
+#    branches:
+#      - pingcap/provider-aws
 
 env:
   GO_VERSION: '1.14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
       - pingcap/provider-aws
     tags:
       - "*"
+  # Uncomment below lines to debug this action in PR
+  pull_request:
+    branches:
+      - pingcap/provider-aws
 
 env:
   GO_VERSION: '1.14'
@@ -50,12 +54,18 @@ jobs:
         working-directory: ./
         run: CGO_ENABLED=0 GOOS=linux go build -o docker/crossplane-aws-provider cmd/provider/main.go
       
-      - name: Setup gcloud CLI
-        uses: google-github-actions/setup-gcloud@master
+      - id: auth
+        uses: google-github-actions/auth@v0.4.0
         with:
-          service_account_key: ${{ secrets.PUB_GCR_SA_KEY }}
+          credentials_json: ${{ secrets.PUB_GCR_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0.3.0
+        with:
           project_id: ${{ env.PROJECT_ID }}
-          export_default_credentials: truea
+
+      - name: Test gcloud CLI
+        run: gcloud info
 
       - name: Configure docker to use the gcloud command-line tool as a credential helper
         run: |


### PR DESCRIPTION
We used the main branch of `setup-gcloud` GitHub Action, and the `service_account_key` input was deprecated in recent release, which caused CI failed.