### PR TITLE
Reduce unnecessary AWS API requests

### DIFF
--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -178,6 +178,12 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		}
 	}
 
+	// If vpc peering connection status is pending acceptance, modify vpc peering attributes request will failed.
+	// In order to reduce the API request to AWS, return errors early to avoid unnecessary API requests.
+	if existedPeer.Status.Code == ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance {
+		return managed.ExternalObservation{ResourceExists: true}, fmt.Errorf("Waiting for the user to accept the vpc peering connection")
+	}
+
 	_, routeTableReady := cr.GetAnnotations()[routeTableEnsured]
 	_, hostZoneReady := cr.GetAnnotations()[hostedZoneEnsured]
 	_, attributeReady := cr.GetAnnotations()[attributeModified]

--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -45,12 +45,13 @@ type ConnectionStateReasonCode string
 const (
 	errUnexpectedObject = "managed resource is not an VPCPeeringConnection resource"
 
-	errCreate              = "cannot create VPCPeeringConnection in AWS"
-	errCreateHostzone      = "cannot create HostedZoneAssosciation in AWS"
-	errDescribe            = "failed to describe VPCPeeringConnection"
-	errDescribeRouteTable  = "failed to describe RouteTable"
-	errModifyVpcPeering    = "failed to modify VPCPeeringConnection"
-	errUpdateManagedStatus = "cannot update managed resource status"
+	errCreate                         = "cannot create VPCPeeringConnection in AWS"
+	errCreateHostzone                 = "cannot create HostedZoneAssosciation in AWS"
+	errDescribe                       = "failed to describe VPCPeeringConnection"
+	errDescribeRouteTable             = "failed to describe RouteTable"
+	errModifyVpcPeering               = "failed to modify VPCPeeringConnection"
+	errUpdateManagedStatus            = "cannot update managed resource status"
+	errWaitVpcPeeringConnectionAccept = "waiting for the user to accept the vpc peering connection"
 
 	routeTableEnsured = "tidbcloud.com/route-table-ensured"
 	hostedZoneEnsured = "tidbcloud.com/hosted-zone-ensured"
@@ -181,7 +182,7 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 	// If vpc peering connection status is pending acceptance, modify vpc peering attributes request will failed.
 	// In order to reduce the API request to AWS, return errors early to avoid unnecessary API requests.
 	if existedPeer.Status.Code == ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance {
-		return managed.ExternalObservation{ResourceExists: true}, fmt.Errorf("Waiting for the user to accept the vpc peering connection")
+		return managed.ExternalObservation{ResourceExists: true}, fmt.Errorf(errWaitVpcPeeringConnectionAccept)
 	}
 
 	_, routeTableReady := cr.GetAnnotations()[routeTableEnsured]


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes AWSRateLimit

if the vpc peering connection is pending acceptance, the origin code will call modify the vpc peering attribute, it will be failed because the vpc peering is not active. To reduce API calls, we can return error when the vpc peering  is pendingacceptance


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
