### PR TITLE
add failed and rejected status to vpc peering filter

### DIFF
--- a/pkg/clients/peering/peering.go
+++ b/pkg/clients/peering/peering.go
@@ -32,6 +32,11 @@ func GenerateDescribeVpcPeeringConnectionsInput(cr *svcapitypes.VPCPeeringConnec
 					string(ec2.VpcPeeringConnectionStateReasonCodeActive),
 					string(ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance),
 					string(ec2.VpcPeeringConnectionStateReasonCodeProvisioning),
+					// If the vpc id does not exist, the status of the vpc peering connection will become failed.
+					// Describe result should contains failed vpc peering connection, otherwise the controller will always create peering and eventually api throttling
+					string(ec2.VpcPeeringConnectionStateReasonCodeFailed),
+					// If peer vpc reject connection, we should not create it again.
+					string(ec2.VpcPeeringConnectionStateReasonCodeRejected),
 				},
 			},
 		},

--- a/pkg/controller/vpcpeering/peering_test.go
+++ b/pkg/controller/vpcpeering/peering_test.go
@@ -24,9 +24,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/route53"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	svcapitypes "github.com/crossplane/provider-aws/apis/vpcpeering/v1alpha1"
-
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	svcapitypes "github.com/crossplane/provider-aws/apis/vpcpeering/v1alpha1"
 	"github.com/crossplane/provider-aws/pkg/clients/peering/fake"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/gomega"
@@ -48,8 +48,9 @@ type args struct {
 func TestObserve(t *testing.T) {
 	g := NewGomegaWithT(t)
 	type want struct {
-		result managed.ExternalObservation
-		err    error
+		result       managed.ExternalObservation
+		err          error
+		expectStatus *svcapitypes.VPCPeeringConnectionStatus
 	}
 
 	cases := map[string]struct {
@@ -218,13 +219,6 @@ func TestObserve(t *testing.T) {
 							}},
 						}
 					},
-					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
-						return ec2.DescribeRouteTablesRequest{
-							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
-								RouteTables: make([]ec2.RouteTable, 0),
-							}},
-						}
-					},
 				},
 			},
 			want: want{
@@ -321,6 +315,92 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
+		"Failed": {
+			args: args{
+				kube: &test.MockClient{
+					MockUpdate: test.NewMockClient().Update,
+					MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+				cr: buildVPCPeerConnection("test"),
+				client: &fake.MockEC2Client{
+					DescribeVpcPeeringConnectionsRequestFun: func(input *ec2.DescribeVpcPeeringConnectionsInput) ec2.DescribeVpcPeeringConnectionsRequest {
+						return ec2.DescribeVpcPeeringConnectionsRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeVpcPeeringConnectionsOutput{
+								VpcPeeringConnections: []ec2.VpcPeeringConnection{
+									{
+										Status: &ec2.VpcPeeringConnectionStateReason{
+											Code: ec2.VpcPeeringConnectionStateReasonCodeFailed,
+										},
+										VpcPeeringConnectionId: aws.String("peerConnectionID"),
+									},
+								},
+							}},
+						}
+					},
+				},
+			},
+			want: want{
+				result: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        false,
+					ResourceLateInitialized: false,
+				},
+				expectStatus: &svcapitypes.VPCPeeringConnectionStatus{
+					ResourceStatus: xpv1.ResourceStatus{ConditionedStatus: xpv1.ConditionedStatus{Conditions: []xpv1.Condition{
+						xpv1.Unavailable(),
+					}}},
+					AtProvider: svcapitypes.VPCPeeringConnectionObservation{
+						Status:                 &svcapitypes.VPCPeeringConnectionStateReason{Code: aws.String("failed")},
+						VPCPeeringConnectionID: aws.String("peerConnectionID"),
+					},
+				},
+			},
+		},
+		"Rejected": {
+			args: args{
+				kube: &test.MockClient{
+					MockUpdate: test.NewMockClient().Update,
+					MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+						return nil
+					},
+				},
+				cr: buildVPCPeerConnection("test"),
+				client: &fake.MockEC2Client{
+					DescribeVpcPeeringConnectionsRequestFun: func(input *ec2.DescribeVpcPeeringConnectionsInput) ec2.DescribeVpcPeeringConnectionsRequest {
+						return ec2.DescribeVpcPeeringConnectionsRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeVpcPeeringConnectionsOutput{
+								VpcPeeringConnections: []ec2.VpcPeeringConnection{
+									{
+										Status: &ec2.VpcPeeringConnectionStateReason{
+											Code: ec2.VpcPeeringConnectionStateReasonCodeRejected,
+										},
+										VpcPeeringConnectionId: aws.String("peerConnectionID"),
+									},
+								},
+							}},
+						}
+					},
+				},
+			},
+			want: want{
+				result: managed.ExternalObservation{
+					ResourceExists:          true,
+					ResourceUpToDate:        false,
+					ResourceLateInitialized: false,
+				},
+				expectStatus: &svcapitypes.VPCPeeringConnectionStatus{
+					ResourceStatus: xpv1.ResourceStatus{ConditionedStatus: xpv1.ConditionedStatus{Conditions: []xpv1.Condition{
+						xpv1.Unavailable(),
+					}}},
+					AtProvider: svcapitypes.VPCPeeringConnectionObservation{
+						Status:                 &svcapitypes.VPCPeeringConnectionStateReason{Code: aws.String("rejected")},
+						VPCPeeringConnectionID: aws.String("peerConnectionID"),
+					},
+				},
+			},
+		},
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -341,6 +421,11 @@ func TestObserve(t *testing.T) {
 
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+			if tc.want.expectStatus != nil {
+				if diff := cmp.Diff(*tc.want.expectStatus, tc.cr.Status); diff != "" {
+					t.Errorf("r: -want, +got:\n%s", diff)
+				}
 			}
 		})
 	}

--- a/pkg/controller/vpcpeering/peering_test.go
+++ b/pkg/controller/vpcpeering/peering_test.go
@@ -356,6 +356,7 @@ func TestObserve(t *testing.T) {
 						VPCPeeringConnectionID: aws.String("peerConnectionID"),
 					},
 				},
+				err: fmt.Errorf("Peering peerConnectionID is not active"),
 			},
 		},
 		"Rejected": {
@@ -399,6 +400,7 @@ func TestObserve(t *testing.T) {
 						VPCPeeringConnectionID: aws.String("peerConnectionID"),
 					},
 				},
+				err: fmt.Errorf("Peering peerConnectionID is not active"),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

- If the vpc id does not exist, the status of the vpc peering connection will become failed. Describe result should contain failed vpc peering connection, otherwise, the controller will always create peering and eventually API throttling
- If peer vpc rejects the connection, we should not create it again.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
If peering is failed, the status is like below
```yaml
status:
  atProvider:
   ...
    status:
      code: failed
      message: Failed due to incorrect VPC-ID, Account ID, or overlapping CIDR range
    vpcPeeringConnectionID: ******
  conditions:
  - lastTransitionTime: "2022-01-14T08:22:48Z"
    reason: Unavailable
    status: "False"
    type: Ready
  - lastTransitionTime: "2022-01-14T08:43:08Z"
    message: 'observe failed: Peering ****** is not active'
    reason: ReconcileError
    status: "False"
    type: Synced
```

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
