### PR TITLE
Fix vpc peering can not deleted when hosted zone is empty

### DIFF
--- a/pkg/controller/vpcpeering/peering_test.go
+++ b/pkg/controller/vpcpeering/peering_test.go
@@ -694,6 +694,61 @@ func TestDelete(t *testing.T) {
 				err: nil,
 			},
 		},
+		"EmptyHostedZone": {
+			args: args{
+				kube: &test.MockClient{
+					MockDelete: test.NewMockClient().Delete,
+				},
+				route53Cli: &fake.MockRoute53Client{
+					// When the function is called, it will return an error directly. if host zone is empty, this function should not be called
+					DeleteVPCAssociationAuthorizationRequestFun: func(input *route53.DeleteVPCAssociationAuthorizationInput) route53.DeleteVPCAssociationAuthorizationRequest {
+						return route53.DeleteVPCAssociationAuthorizationRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &route53.DeleteVPCAssociationAuthorizationOutput{}, Error: fmt.Errorf("missing required field, DeleteVPCAssociationAuthorizationInput.HostedZoneId")},
+						}
+					},
+				},
+				cr: hostedZoneEmptyVPCPeerConnection("hostzone-zone-empty"),
+				client: &fake.MockEC2Client{
+					DescribeRouteTablesRequestFun: func(input *ec2.DescribeRouteTablesInput) ec2.DescribeRouteTablesRequest {
+						return ec2.DescribeRouteTablesRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeRouteTablesOutput{
+								RouteTables: make([]ec2.RouteTable, 0),
+							}},
+						}
+					},
+					DescribeVpcPeeringConnectionsRequestFun: func(input *ec2.DescribeVpcPeeringConnectionsInput) ec2.DescribeVpcPeeringConnectionsRequest {
+						return ec2.DescribeVpcPeeringConnectionsRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DescribeVpcPeeringConnectionsOutput{
+								//Attributes: attributes,
+								VpcPeeringConnections: []ec2.VpcPeeringConnection{
+									{
+										Status: &ec2.VpcPeeringConnectionStateReason{
+											Code: ec2.VpcPeeringConnectionStateReasonCodePendingAcceptance,
+										},
+
+										Tags: []ec2.Tag{
+											{
+												Key:   aws.String("Name"),
+												Value: aws.String("test"),
+											},
+										},
+										VpcPeeringConnectionId: aws.String("pcx-xxx"),
+									},
+								},
+							}},
+						}
+					},
+					DeleteVpcPeeringConnectionRequestFun: func(input *ec2.DeleteVpcPeeringConnectionInput) ec2.DeleteVpcPeeringConnectionRequest {
+						return ec2.DeleteVpcPeeringConnectionRequest{
+							Request: &aws.Request{HTTPRequest: &http.Request{}, Retryer: aws.NoOpRetryer{}, Data: &ec2.DeleteVpcPeeringConnectionOutput{}},
+						}
+					},
+				},
+			},
+			want: want{
+				err: nil,
+			},
+		},
 	}
 
 	for name, tc := range cases {
@@ -1007,5 +1062,12 @@ func inDeletingVPCPeerConnection(name string) *svcapitypes.VPCPeeringConnection 
 	cr := buildVPCPeerConnection(name)
 
 	cr.DeletionTimestamp = &v1.Time{time.Now()}
+	return cr
+}
+
+func hostedZoneEmptyVPCPeerConnection(name string) *svcapitypes.VPCPeeringConnection {
+	cr := buildVPCPeerConnection(name)
+	// set hostedZone to empty
+	cr.Spec.ForProvider.HostZoneID = nil
 	return cr
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
