### PR TITLE
fix s3 tag forcelly rewrited

### DIFF
--- a/pkg/controller/s3/bucket/taggingConfig.go
+++ b/pkg/controller/s3/bucket/taggingConfig.go
@@ -18,12 +18,11 @@ package bucket
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go/aws"
 
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/google/go-cmp/cmp"
-
 	"github.com/crossplane/provider-aws/apis/s3/v1beta1"
 	awsclient "github.com/crossplane/provider-aws/pkg/clients"
 	"github.com/crossplane/provider-aws/pkg/clients/s3"
@@ -61,11 +60,28 @@ func (in *TaggingConfigurationClient) Observe(ctx context.Context, bucket *v1bet
 		return Updated, nil
 	case config == nil && len(external.TagSet) != 0:
 		return NeedsDeletion, nil
-	case cmp.Equal(s3.SortS3TagSet(external.TagSet), s3.SortS3TagSet(GenerateTagging(config).TagSet)):
+	case !IsSubsetTags(GenerateTagging(config).TagSet, external.TagSet):
 		return Updated, nil
 	default:
 		return NeedsUpdate, nil
 	}
+}
+
+func IsSubsetTags(generatedTagSet []awss3.Tag, externalTagSets []awss3.Tag) bool {
+	for _, tag := range generatedTagSet {
+		found := false
+		for _, externalTagSet := range externalTagSets {
+			if aws.StringValue(tag.Key) == aws.StringValue(externalTagSet.Key) &&
+				aws.StringValue(tag.Value) == aws.StringValue(externalTagSet.Value) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 // CreateOrUpdate sends a request to have resource created on AWS

--- a/pkg/controller/s3/bucket/taggingConfig_test.go
+++ b/pkg/controller/s3/bucket/taggingConfig_test.go
@@ -46,7 +46,8 @@ var (
 		Key:   "abc",
 		Value: "abc",
 	}
-	tags   = []v1beta1.Tag{tag, tag1, tag2}
+	tags = []v1beta1.Tag{tag, tag1, tag2}
+
 	awsTag = s3.Tag{
 		Key:   aws.String("test"),
 		Value: aws.String("value"),
@@ -61,6 +62,23 @@ var (
 	}
 	awsTags                   = []s3.Tag{awsTag, awsTag1, awsTag2}
 	_       SubresourceClient = &TaggingConfigurationClient{}
+
+	fooTag1 = s3.Tag{
+		Key:   aws.String("foo"),
+		Value: aws.String("123456"),
+	}
+	fooTag2 = s3.Tag{
+		Key:   aws.String("bar"),
+		Value: aws.String("34567"),
+	}
+	fooTag3 = s3.Tag{
+		Key:   aws.String("zoo"),
+		Value: aws.String("backup"),
+	}
+	fooTag4 = s3.Tag{
+		Key:   aws.String("foo"),
+		Value: aws.String("1234567"),
+	}
 )
 
 func generateTaggingConfig() *v1beta1.Tagging {
@@ -214,6 +232,32 @@ func TestTaggingObserve(t *testing.T) {
 				t.Errorf("r: -want, +got:\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestS3SubsetTags(t *testing.T) {
+	observedTags := []s3.Tag{fooTag1, fooTag2, fooTag3}
+	generatedTags := []s3.Tag{fooTag1, fooTag2}
+
+	result := IsSubsetTags(generatedTags, observedTags)
+	if !result {
+		t.Fatal("Expect generatedTags is subset of observedTags")
+	}
+
+	observedTags = []s3.Tag{fooTag2, fooTag3, fooTag4}
+	generatedTags = []s3.Tag{fooTag1, fooTag2}
+
+	result = IsSubsetTags(generatedTags, observedTags)
+	if result {
+		t.Fatal("Expect generatedTags is not a subset of observedTags")
+	}
+
+	observedTags = []s3.Tag{fooTag1, fooTag3}
+	generatedTags = []s3.Tag{fooTag1, fooTag2}
+
+	result = IsSubsetTags(generatedTags, observedTags)
+	if result {
+		t.Fatal("Expect generatedTags is not a subset of observedTags")
 	}
 }
 


### PR DESCRIPTION
if s3 tag contains: [tag1, tag2, tag3], but the crossplane s3 config tag
is [tag1, tag2], provider-aws will forcelly rewrite the tags with [tag1,
tag2]. This is not as expected in some situations.
