### PR TITLE
delete route table destination when the route table status is blackhole

### DIFF
--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -557,6 +557,7 @@ func (e *external) addRoute(ctx context.Context, client peering.EC2Client, name 
 									}
 								}
 								e.log.WithValues("VpcPeering", name).Debug("Delete route successful", "RouteTableId", rt.RouteTableId)
+								continue
 							}
 
 							return errors.Wrap(err, fmt.Sprintf("failed add route for vpc peering connection: %s, routeID: %s", *pcx, *rt.RouteTableId))

--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -532,6 +532,23 @@ func (e *external) addRoute(ctx context.Context, client peering.EC2Client, name 
 			DestinationCidrBlock:   aws.String(peerCIDR),
 			VpcPeeringConnectionId: pcx,
 		}
+
+		// If the route table exists, and the state is blackhole, remove it.
+		for _, route := range rt.Routes {
+			if route.DestinationCidrBlock != nil && *route.DestinationCidrBlock == peerCIDR && route.State == ec2.RouteStateBlackhole {
+				_, err := client.DeleteRouteRequest(&ec2.DeleteRouteInput{
+					DestinationCidrBlock: aws.String(peerCIDR),
+					RouteTableId:         rt.RouteTableId,
+				}).Send(ctx)
+				if err != nil {
+					if !strings.Contains(err.Error(), "InvalidRoute.NotFound") {
+						return errors.Wrap(err, "delete Route")
+					}
+				}
+				e.log.WithValues("VpcPeering", name).Debug("Delete route successful", "RouteTableId", rt.RouteTableId)
+			}
+		}
+
 		_, err := client.CreateRouteRequest(createRouteInput).Send(ctx)
 		if err != nil {
 			// FIXME: The error is not aws.Err type?
@@ -545,21 +562,6 @@ func (e *external) addRoute(ctx context.Context, client peering.EC2Client, name 
 							e.log.WithValues("VpcPeering", name).Debug("Route already exist, no need to recreate", "RouteTableId", rt.RouteTableId, "DestinationCidrBlock", *route.DestinationCidrBlock)
 							continue
 						} else {
-							// If the route table exists, and the state is blackhole, remove it.
-							if route.State == ec2.RouteStateBlackhole {
-								_, err := client.DeleteRouteRequest(&ec2.DeleteRouteInput{
-									DestinationCidrBlock: aws.String(peerCIDR),
-									RouteTableId:         rt.RouteTableId,
-								}).Send(ctx)
-								if err != nil {
-									if !strings.Contains(err.Error(), "InvalidRoute.NotFound") {
-										return errors.Wrap(err, "delete Route")
-									}
-								}
-								e.log.WithValues("VpcPeering", name).Debug("Delete route successful", "RouteTableId", rt.RouteTableId)
-								continue
-							}
-
 							return errors.Wrap(err, fmt.Sprintf("failed add route for vpc peering connection: %s, routeID: %s", *pcx, *rt.RouteTableId))
 						}
 					}

--- a/pkg/controller/vpcpeering/peering.go
+++ b/pkg/controller/vpcpeering/peering.go
@@ -545,7 +545,7 @@ func (e *external) addRoute(ctx context.Context, client peering.EC2Client, name 
 						return errors.Wrap(err, "delete Route")
 					}
 				}
-				e.log.WithValues("VpcPeering", name).Debug("Delete route successful", "RouteTableId", rt.RouteTableId)
+				e.log.WithValues("VpcPeering", name).Debug("Delete the occupied route whose route is in blackhole successful", "RouteTableId", rt.RouteTableId)
 			}
 		}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

We should remove the route table record in blackhole first to avoid the dead record blocking the VPC peering request.

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
