### PR TITLE
Enable required resources

### DIFF
--- a/apis/aws.go
+++ b/apis/aws.go
@@ -29,6 +29,7 @@ import (
 	elbv2v1alpha1 "github.com/crossplane/provider-aws/apis/elbv2/v1alpha1"
 	iamv1beta1 "github.com/crossplane/provider-aws/apis/iam/v1beta1"
 	kmsv1alpha1 "github.com/crossplane/provider-aws/apis/kms/v1alpha1"
+	lambdav1alpha1 "github.com/crossplane/provider-aws/apis/lambda/v1alpha1"
 	route53v1alpha1 "github.com/crossplane/provider-aws/apis/route53/v1alpha1"
 	s3v1alpha2 "github.com/crossplane/provider-aws/apis/s3/v1alpha3"
 	s3v1beta1 "github.com/crossplane/provider-aws/apis/s3/v1beta1"
@@ -53,6 +54,7 @@ func init() {
 		sqsv1beta1.SchemeBuilder.AddToScheme,
 		kmsv1alpha1.SchemeBuilder.AddToScheme,
 		ec2v1alpha1.SchemeBuilder.AddToScheme,
+		lambdav1alpha1.SchemeBuilder.AddToScheme,
 		peeringv1alpha1.SchemeBuilder.AddToScheme,
 		eksv1beta1.SchemeBuilder.AddToScheme,
 		eksv1alpha1.SchemeBuilder.AddToScheme,

--- a/pkg/controller/aws.go
+++ b/pkg/controller/aws.go
@@ -31,6 +31,8 @@ import (
 
 	"github.com/crossplane/provider-aws/pkg/controller/config"
 	"github.com/crossplane/provider-aws/pkg/controller/ec2/vpc"
+	"github.com/crossplane/provider-aws/pkg/controller/ec2/vpcendpoint"
+	"github.com/crossplane/provider-aws/pkg/controller/ec2/vpcendpointserviceconfiguration"
 	"github.com/crossplane/provider-aws/pkg/controller/eks"
 	"github.com/crossplane/provider-aws/pkg/controller/eks/nodegroup"
 	"github.com/crossplane/provider-aws/pkg/controller/elasticloadbalancing/elb"
@@ -63,6 +65,8 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll ti
 		role.SetupRole,
 		rolepolicyattachment.SetupRolePolicyAttachment,
 		function.SetupFunction,
+		vpcendpoint.SetupVPCEndpoint,
+		vpcendpointserviceconfiguration.SetupVPCEndpointServiceConfiguration,
 	} {
 		if err := setup(mgr, l, rl, poll); err != nil {
 			return err

--- a/pkg/controller/aws.go
+++ b/pkg/controller/aws.go
@@ -36,6 +36,7 @@ import (
 	"github.com/crossplane/provider-aws/pkg/controller/elasticloadbalancing/elb"
 	"github.com/crossplane/provider-aws/pkg/controller/elasticloadbalancing/elbattachment"
 	"github.com/crossplane/provider-aws/pkg/controller/kms/key"
+	"github.com/crossplane/provider-aws/pkg/controller/lambda/function"
 	"github.com/crossplane/provider-aws/pkg/controller/route53/hostedzone"
 	"github.com/crossplane/provider-aws/pkg/controller/route53/resourcerecordset"
 	"github.com/crossplane/provider-aws/pkg/controller/s3"
@@ -61,6 +62,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll ti
 		policy.SetupPolicy,
 		role.SetupRole,
 		rolepolicyattachment.SetupRolePolicyAttachment,
+		function.SetupFunction,
 	} {
 		if err := setup(mgr, l, rl, poll); err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Some changes in [tangent/merge-upstream-new-controllers](https://github.com/tidbcloud/provider-aws/tree/tangent/merge-upstream-new-controllers) are not merged when #37 is merged.
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Built a new image with the change. The pods is running as expected:
```
➜  ~ k -n infra get pod aws-provider-68c4ccf576-mq5p7
NAME                            READY   STATUS    RESTARTS   AGE
aws-provider-68c4ccf576-mq5p7   1/1     Running   0          77s
```

The function resource is being reconciled as expected:
```
➜  ~ kubectl get function nightly-ms-43531-eks-us-west-2-f3b3a3ed-db10428f -w
NAME                                               READY   SYNCED   EXTERNAL-NAME
nightly-ms-43531-eks-us-west-2-f3b3a3ed-db10428f   True    True     nightly-ms-43531-eks-us-west-2-f3b3a3ed-db10428f
```

[contribution process]: https://git.io/fj2m9
