### PR TITLE
fix(iam): avoid OIDC provider tag scan

### DIFF
--- a/pkg/controller/iam/openidconnectprovider/controller.go
+++ b/pkg/controller/iam/openidconnectprovider/controller.go
@@ -18,8 +18,10 @@ package openidconnectprovider
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	awsarn "github.com/aws/aws-sdk-go-v2/aws/arn"
 	awsiam "github.com/aws/aws-sdk-go-v2/service/iam"
 	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
@@ -125,7 +127,7 @@ func (e *external) Observe(ctx context.Context, mgd resource.Managed) (managed.E
 	}
 
 	if meta.GetExternalName(cr) == "" {
-		arn, err := e.getOpenIDConnectProviderByTags(ctx, resource.GetExternalTags(mgd))
+		arn, err := e.getOpenIDConnectProviderByTags(ctx, cr.Spec.ForProvider.URL, resource.GetExternalTags(mgd))
 		if arn == nil || err != nil {
 			return managed.ExternalObservation{}, resource.Ignore(iam.IsErrorNotFound, err)
 		}
@@ -267,29 +269,63 @@ func (e *external) Delete(ctx context.Context, mgd resource.Managed) error {
 	return errorutils.Wrap(resource.Ignore(iam.IsErrorNotFound, err), errDelete)
 }
 
-func (e *external) getOpenIDConnectProviderByTags(ctx context.Context, tags map[string]string) (*string, error) {
+func oidcARNMatchesURL(providerARN, providerURL string) bool {
+	issuer, ok := strings.CutPrefix(providerURL, "https://")
+	if !ok || issuer == "" {
+		return false
+	}
+
+	parsed, err := awsarn.Parse(providerARN)
+	if err != nil {
+		return false
+	}
+
+	return parsed.Service == "iam" &&
+		parsed.Region == "" &&
+		parsed.Resource == "oidc-provider/"+issuer
+}
+
+func findOIDCProviderARNByURL(providers []iamtypes.OpenIDConnectProviderListEntry, providerURL string) *string {
+	for _, provider := range providers {
+		if oidcARNMatchesURL(aws.ToString(provider.Arn), providerURL) {
+			return provider.Arn
+		}
+	}
+	return nil
+}
+
+func (e *external) getOpenIDConnectProviderByTags(ctx context.Context, providerURL string, tags map[string]string) (*string, error) {
 	name, ok := tags[resource.ExternalResourceTagKeyName]
 	if !ok {
 		return nil, nil
 	}
 
 	oidcs, err := e.client.ListOpenIDConnectProviders(ctx, &awsiam.ListOpenIDConnectProvidersInput{})
-	if err != nil || len(oidcs.OpenIDConnectProviderList) == 0 {
+	if err != nil {
 		return nil, errorutils.Wrap(err, errList)
 	}
+	if oidcs == nil {
+		return nil, errors.New(errList)
+	}
 
-	for _, o := range oidcs.OpenIDConnectProviderList {
-		tags, err := e.client.ListOpenIDConnectProviderTags(ctx, &awsiam.ListOpenIDConnectProviderTagsInput{
-			OpenIDConnectProviderArn: o.Arn,
-		})
-		if err != nil {
-			return nil, errorutils.Wrap(err, errListTags)
-		}
+	providerARN := findOIDCProviderARNByURL(oidcs.OpenIDConnectProviderList, providerURL)
+	if providerARN == nil {
+		return nil, nil
+	}
 
-		for _, t := range tags.Tags {
-			if *t.Key == resource.ExternalResourceTagKeyName && *t.Value == name {
-				return o.Arn, nil
-			}
+	observedTags, err := e.client.ListOpenIDConnectProviderTags(ctx, &awsiam.ListOpenIDConnectProviderTagsInput{
+		OpenIDConnectProviderArn: providerARN,
+	})
+	if err != nil {
+		return nil, errorutils.Wrap(err, errListTags)
+	}
+	if observedTags == nil {
+		return nil, errors.New(errListTags)
+	}
+
+	for _, t := range observedTags.Tags {
+		if aws.ToString(t.Key) == resource.ExternalResourceTagKeyName && aws.ToString(t.Value) == name {
+			return providerARN, nil
 		}
 	}
 	return nil, nil

--- a/pkg/controller/iam/openidconnectprovider/controller_test.go
+++ b/pkg/controller/iam/openidconnectprovider/controller_test.go
@@ -18,6 +18,7 @@ package openidconnectprovider
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -42,7 +43,7 @@ import (
 
 var (
 	unexpectedItem resource.Managed
-	providerArn    = "arn:123"
+	providerArn    = "arn:aws:iam::123456789012:oidc-provider/example.com"
 	url            = "https://example.com"
 	name           = "oidcProvider"
 
@@ -144,6 +145,14 @@ func oidcProvider(m ...oidcProviderModifier) *svcapitypes.OpenIDConnectProvider 
 		f(cr)
 	}
 	return cr
+}
+
+func oidcProviderList(n int) []iamtypes.OpenIDConnectProviderListEntry {
+	providers := make([]iamtypes.OpenIDConnectProviderListEntry, n)
+	for i := range providers {
+		providers[i].Arn = aws.String(fmt.Sprintf("arn:aws:iam::123456789012:oidc-provider/unrelated-%03d.example.com", i))
+	}
+	return providers
 }
 
 func TestObserve(t *testing.T) {
@@ -319,6 +328,343 @@ func TestObserve(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.result, o); diff != "" {
 				t.Errorf("r: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestOIDCARNMatchesURL(t *testing.T) {
+	cases := map[string]struct {
+		providerARN string
+		providerURL string
+		want        bool
+	}{
+		"CommercialPartition": {
+			providerARN: providerArn,
+			providerURL: url,
+			want:        true,
+		},
+		"GKEPath": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/container.googleapis.com/v1/projects/project/locations/us-central1/clusters/cluster",
+			providerURL: "https://container.googleapis.com/v1/projects/project/locations/us-central1/clusters/cluster",
+			want:        true,
+		},
+		"EKSPathWithTrailingSlash": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/oidc.eks.us-west-2.amazonaws.com/id/issuer/",
+			providerURL: "https://oidc.eks.us-west-2.amazonaws.com/id/issuer/",
+			want:        true,
+		},
+		"ChinaPartition": {
+			providerARN: "arn:aws-cn:iam::123456789012:oidc-provider/example.com/path",
+			providerURL: "https://example.com/path",
+			want:        true,
+		},
+		"GovCloudPartition": {
+			providerARN: "arn:aws-us-gov:iam::123456789012:oidc-provider/example.com/path",
+			providerURL: "https://example.com/path",
+			want:        true,
+		},
+		"DifferentPath": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/example.com/path-a",
+			providerURL: "https://example.com/path-b",
+		},
+		"PathPrefixOnly": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/example.com/clusters/cluster-extra",
+			providerURL: "https://example.com/clusters/cluster",
+		},
+		"CaseMismatch": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/Example.com/Path",
+			providerURL: "https://example.com/Path",
+		},
+		"TrailingSlashMismatch": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/example.com/path/",
+			providerURL: "https://example.com/path",
+		},
+		"PercentEscapeLiteralMatch": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/example.com/a%2Fb",
+			providerURL: "https://example.com/a%2Fb",
+			want:        true,
+		},
+		"PercentEscapeCaseMismatch": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/example.com/a%2Fb",
+			providerURL: "https://example.com/a%2fb",
+		},
+		"PortLiteralMatch": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/example.com:8443/path",
+			providerURL: "https://example.com:8443/path",
+			want:        true,
+		},
+		"WrongService": {
+			providerARN: "arn:aws:sts::123456789012:oidc-provider/example.com",
+			providerURL: url,
+		},
+		"RegionalIAMARN": {
+			providerARN: "arn:aws:iam:us-east-1:123456789012:oidc-provider/example.com",
+			providerURL: url,
+		},
+		"WrongResourceType": {
+			providerARN: "arn:aws:iam::123456789012:role/example.com",
+			providerURL: url,
+		},
+		"MalformedARN": {
+			providerARN: "arn:123",
+			providerURL: url,
+		},
+		"EmptyARN": {
+			providerURL: url,
+		},
+		"HTTPURL": {
+			providerARN: providerArn,
+			providerURL: "http://example.com",
+		},
+		"EmptyURL": {
+			providerARN: providerArn,
+		},
+		"EmptyIssuer": {
+			providerARN: "arn:aws:iam::123456789012:oidc-provider/",
+			providerURL: "https://",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := oidcARNMatchesURL(tc.providerARN, tc.providerURL); got != tc.want {
+				t.Errorf("oidcARNMatchesURL(%q, %q) = %t, want %t", tc.providerARN, tc.providerURL, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGetOpenIDConnectProviderByTagsFiltersByURL(t *testing.T) {
+	matchingProviders := oidcProviderList(164)
+	matchingProviders[len(matchingProviders)-1].Arn = aws.String(providerArn)
+	correctOwnershipTag := &awsiam.ListOpenIDConnectProviderTagsOutput{Tags: []iamtypes.Tag{{
+		Key:   aws.String(resource.ExternalResourceTagKeyName),
+		Value: aws.String(name),
+	}}}
+
+	type want struct {
+		arn       *string
+		err       error
+		listCalls int
+		tagCalls  int
+		tagARN    string
+	}
+	cases := map[string]struct {
+		providerURL  string
+		externalTags map[string]string
+		listOutput   *awsiam.ListOpenIDConnectProvidersOutput
+		listErr      error
+		tagOutput    *awsiam.ListOpenIDConnectProviderTagsOutput
+		tagsByARN    map[string]*awsiam.ListOpenIDConnectProviderTagsOutput
+		tagErr       error
+		want
+	}{
+		"NoExpectedNameTag": {
+			providerURL: url,
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{{Arn: aws.String(providerArn)}},
+			},
+		},
+		"NoMatchingURLAmong164Providers": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: oidcProviderList(164),
+			},
+			tagOutput: &awsiam.ListOpenIDConnectProviderTagsOutput{},
+			want: want{
+				listCalls: 1,
+			},
+		},
+		"MatchingURLIsLastAmong164Providers": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: matchingProviders,
+			},
+			tagOutput: &awsiam.ListOpenIDConnectProviderTagsOutput{},
+			tagsByARN: map[string]*awsiam.ListOpenIDConnectProviderTagsOutput{
+				providerArn: correctOwnershipTag,
+			},
+			want: want{
+				arn:       aws.String(providerArn),
+				listCalls: 1,
+				tagCalls:  1,
+				tagARN:    providerArn,
+			},
+		},
+		"MatchingURLWrongOwnershipTag": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{{Arn: aws.String(providerArn)}},
+			},
+			tagOutput: &awsiam.ListOpenIDConnectProviderTagsOutput{Tags: []iamtypes.Tag{{
+				Key:   aws.String(resource.ExternalResourceTagKeyName),
+				Value: aws.String("different-name"),
+			}}},
+			want: want{
+				listCalls: 1,
+				tagCalls:  1,
+				tagARN:    providerArn,
+			},
+		},
+		"MatchingURLMissingOwnershipTag": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{{Arn: aws.String(providerArn)}},
+			},
+			tagOutput: &awsiam.ListOpenIDConnectProviderTagsOutput{},
+			want: want{
+				listCalls: 1,
+				tagCalls:  1,
+				tagARN:    providerArn,
+			},
+		},
+		"NilTagFieldsDoNotMatch": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{{Arn: aws.String(providerArn)}},
+			},
+			tagOutput: &awsiam.ListOpenIDConnectProviderTagsOutput{Tags: []iamtypes.Tag{
+				{Value: aws.String(name)},
+				{Key: aws.String(resource.ExternalResourceTagKeyName)},
+			}},
+			want: want{
+				listCalls: 1,
+				tagCalls:  1,
+				tagARN:    providerArn,
+			},
+		},
+		"DifferentURLWithSameNameTagIsNotAdopted": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{{
+					Arn: aws.String("arn:aws:iam::123456789012:oidc-provider/different.example.com"),
+				}},
+			},
+			tagOutput: correctOwnershipTag,
+			want: want{
+				listCalls: 1,
+			},
+		},
+		"MalformedAndNilARNsAreSkipped": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+					{},
+					{Arn: aws.String("arn:123")},
+					{Arn: aws.String("arn:aws:iam::123456789012:role/example.com")},
+				},
+			},
+			tagOutput: correctOwnershipTag,
+			want: want{
+				listCalls: 1,
+			},
+		},
+		"DuplicateMatchingARNIsCheckedOnce": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{
+					{Arn: aws.String(providerArn)},
+					{Arn: aws.String(providerArn)},
+				},
+			},
+			tagOutput: correctOwnershipTag,
+			want: want{
+				arn:       aws.String(providerArn),
+				listCalls: 1,
+				tagCalls:  1,
+				tagARN:    providerArn,
+			},
+		},
+		"ListError": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listErr:      errBoom,
+			want: want{
+				err:       errorutils.Wrap(errBoom, errList),
+				listCalls: 1,
+			},
+		},
+		"NilListOutput": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			want: want{
+				err:       errors.New(errList),
+				listCalls: 1,
+			},
+		},
+		"MatchingURLTagError": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{{Arn: aws.String(providerArn)}},
+			},
+			tagErr: errBoom,
+			want: want{
+				err:       errorutils.Wrap(errBoom, errListTags),
+				listCalls: 1,
+				tagCalls:  1,
+				tagARN:    providerArn,
+			},
+		},
+		"MatchingURLNilTagOutput": {
+			providerURL:  url,
+			externalTags: map[string]string{resource.ExternalResourceTagKeyName: name},
+			listOutput: &awsiam.ListOpenIDConnectProvidersOutput{
+				OpenIDConnectProviderList: []iamtypes.OpenIDConnectProviderListEntry{{Arn: aws.String(providerArn)}},
+			},
+			want: want{
+				err:       errors.New(errListTags),
+				listCalls: 1,
+				tagCalls:  1,
+				tagARN:    providerArn,
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			listCalls := 0
+			tagCalls := 0
+			client := &fake.MockOpenIDConnectProviderClient{
+				MockListOpenIDConnectProviders: func(ctx context.Context, input *awsiam.ListOpenIDConnectProvidersInput, opts []func(*awsiam.Options)) (*awsiam.ListOpenIDConnectProvidersOutput, error) {
+					listCalls++
+					return tc.listOutput, tc.listErr
+				},
+				MockListOpenIDConnectProviderTags: func(ctx context.Context, input *awsiam.ListOpenIDConnectProviderTagsInput, opts []func(*awsiam.Options)) (*awsiam.ListOpenIDConnectProviderTagsOutput, error) {
+					tagCalls++
+					if tc.want.tagARN != "" && aws.ToString(input.OpenIDConnectProviderArn) != tc.want.tagARN {
+						t.Errorf("ListOpenIDConnectProviderTags ARN = %q, want %q", aws.ToString(input.OpenIDConnectProviderArn), tc.want.tagARN)
+					}
+					if output, ok := tc.tagsByARN[aws.ToString(input.OpenIDConnectProviderArn)]; ok {
+						return output, tc.tagErr
+					}
+					return tc.tagOutput, tc.tagErr
+				},
+			}
+
+			e := &external{client: client}
+			got, err := e.getOpenIDConnectProviderByTags(context.Background(), tc.providerURL, tc.externalTags)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("error: -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.arn, got); diff != "" {
+				t.Errorf("ARN: -want, +got:\n%s", diff)
+			}
+			if listCalls != tc.want.listCalls {
+				t.Errorf("ListOpenIDConnectProviders calls = %d, want %d", listCalls, tc.want.listCalls)
+			}
+			if tagCalls != tc.want.tagCalls {
+				t.Errorf("ListOpenIDConnectProviderTags calls = %d, want %d", tagCalls, tc.want.tagCalls)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

When an `OpenIDConnectProvider` managed resource has no external-name annotation, the controller lists every IAM OIDC provider and calls `ListOpenIDConnectProviderTags` sequentially until it finds a matching `crossplane-name` tag.

In an account with many OIDC providers, a no-match observation performs `1 + N` logical IAM SDK operations. Concurrent reconciliations and SDK retries amplify the request volume, which can cause IAM throttling or reconciliation timeouts. Because the external name is still empty after a failed observation, the next reconciliation restarts the same scan.

## Root cause

Discovery used only the ownership tag to identify an existing provider. `ListOpenIDConnectProviders` does not return tags, so the controller fetched tags for every listed ARN even though the desired issuer URL can first narrow discovery to the relevant provider.

## Fix

- Pass the desired issuer URL into OIDC provider discovery.
- Parse each listed ARN and compare its IAM resource exactly with `oidc-provider/<issuer URL without the literal https:// prefix>`.
- Call `ListOpenIDConnectProviderTags` only for the exact URL candidate, reducing logical tag-list calls from `N` to `0` or `1`.
- Preserve the existing exact `crossplane-name` ownership check.
- Safely skip nil or malformed ARNs and handle nil tag fields and nil SDK responses without panics.

The URL comparison is intentionally literal: case, path, trailing slash, percent escapes, and port text are not normalized. The implementation does not hard-code AWS partition or account values.

## Compatibility and risk

This preserves re-adoption for legacy or explicitly tagged providers with the same issuer URL. It intentionally no longer adopts a same-name provider with a different URL, which prevents binding the managed resource to the wrong immutable issuer identity.

provider-aws v0.47 no longer adds standard Crossplane tags automatically. This patch does not restore that initializer or make tagless resources adoptable. An existing provider with the desired URL but without the expected `crossplane-name` tag remains fail-closed; a subsequent create may still return `EntityAlreadyExists`. That is pre-existing behavior and is outside this rate-limit fix.

## Validation

All checks passed:

- `GOTOOLCHAIN=go1.21.13 go test -count=1 ./pkg/controller/iam/openidconnectprovider`
- `GOTOOLCHAIN=go1.21.13 go test -count=1 ./pkg/controller/iam/... ./pkg/clients/iam/...`
- `go test -count=1 ./cmd/... ./pkg/... ./apis/...`
- `GOTOOLCHAIN=go1.21.13 go vet ./pkg/controller/iam/openidconnectprovider`
- `golangci-lint run --allow-parallel-runners pkg/controller/iam/openidconnectprovider/controller.go pkg/controller/iam/openidconnectprovider/controller_test.go`
- `go mod verify`
- `GOTOOLCHAIN=go1.21.13 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /tmp/provider-aws ./cmd/provider`
- `gofmt -d` and `git diff --check`

Regression coverage verifies that 164 unrelated providers cause zero tag-list calls and that a matching provider at position 164 causes exactly one. It also covers GKE and EKS issuer paths, commercial/China/GovCloud partitions, literal URL edge cases, ownership mismatches, malformed/nil fields, and SDK errors.
